### PR TITLE
keyboard-interative event handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,14 @@ module.exports = {
             })
         })
 
+        connection.on('keyboard-interactive', function (name, descr, lang, prompts, finish) {
+            if (_.some(prompts, { prompt: 'Password: ', echo: false })) {
+                return finish([config.password]);
+            } else {
+                return finish(['']);
+            }
+        });
+
         connection.on('error', function(err) {
             debug('Received error from connection: %s:%s. Original error was: ', config.hostname, config.port, err.message)
             once(err)


### PR DESCRIPTION
PR to add a `keyboard-interactive` event handler to return configured password only if the prompt is fulfils the predicate that it is a *password* prompt and the user input should not be displayed on the screen. The `keyboard-interactive` interacts with the `tryKeyboard` option which enforces the `keyboard-interactive` handling. 