### PR TITLE
pass options into `sftp.createWriteStream`

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
             const once = _.once(next);
 
             debug('Creating write stream to %s/%s', connectionUrl, remotePath);
-            const writeStream = sftp.createWriteStream(remotePath);
+            const writeStream = sftp.createWriteStream(remotePath, options);
             const before = Date.now();
 
             writeStream


### PR DESCRIPTION
`options` was not being passed into `sftp.createWriteStream`